### PR TITLE
msys2: Force uninstall of pkgconf

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -134,7 +134,7 @@ class MSYS2Conan(ConanFile):
             for package in packages:
                 self.run('bash -l -c "pacman -S %s --noconfirm"' % package)
             for package in ['pkgconf']:
-                self.run('bash -l -c "pacman -Rs $(pacman -Qsq %s) --noconfirm"' % package)
+                self.run('bash -l -c "pacman -Rs -d -d $(pacman -Qsq %s) --noconfirm"' % package)
 
         self._kill_pacman()
 


### PR DESCRIPTION
pkgconf is required by base-devel, so to really make it gone requires ignoring dependencies