### PR TITLE
qt/5.15.3: Patch missing include and constexpr declarations

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -59,6 +59,6 @@ patches:
     - patch_file: "patches/b498f4ce3f.patch"
       base_path: "qt5/qtwebengine/src/3rdparty"
     - patch_file: "patches/chromium-v8-missing-constexpr.patch"
-      base_path: "qt5/qtwebengine/src/3rdparty"
+      base_path: "qt5/qtwebengine/src/3rdparty/chromium/v8"
     - patch_file: "patches/chromium-skia-missing-iterator-include.patch"
       base_path: "qt5/qtwebengine/src/3rdparty"

--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -58,3 +58,7 @@ patches:
       base_path: "qt5/qtwebengine/src/3rdparty"
     - patch_file: "patches/b498f4ce3f.patch"
       base_path: "qt5/qtwebengine/src/3rdparty"
+    - patch_file: "patches/chromium-v8-missing-constexpr.patch"
+      base_path: "qt5/qtwebengine/src/3rdparty"
+    - patch_file: "patches/chromium-skia-missing-iterator-include.patch"
+      base_path: "qt5/qtwebengine/src/3rdparty"

--- a/recipes/qt/5.x.x/patches/chromium-skia-missing-iterator-include.patch
+++ b/recipes/qt/5.x.x/patches/chromium-skia-missing-iterator-include.patch
@@ -2,8 +2,9 @@ diff --git a/chromium/third_party/skia/src/utils/SkParseColor.cpp b/chromium/thi
 index 7260365b2c6..96f46dd67f9 100644
 --- a/chromium/third_party/skia/src/utils/SkParseColor.cpp
 +++ b/chromium/third_party/skia/src/utils/SkParseColor.cpp
-@@ -9,3 +0,4 @@
+@@ -9,3 +0,5 @@
  #include "include/utils/SkParse.h"
  
 +#include <algorithm> // std::lower_bound
- 
++
+ static constexpr const char* gColorNames[] = {

--- a/recipes/qt/5.x.x/patches/chromium-skia-missing-iterator-include.patch
+++ b/recipes/qt/5.x.x/patches/chromium-skia-missing-iterator-include.patch
@@ -2,11 +2,8 @@ diff --git a/chromium/third_party/skia/src/utils/SkParseColor.cpp b/chromium/thi
 index 7260365b2c6..96f46dd67f9 100644
 --- a/chromium/third_party/skia/src/utils/SkParseColor.cpp
 +++ b/chromium/third_party/skia/src/utils/SkParseColor.cpp
-@@ -5,6 +5,7 @@
-  * found in the LICENSE file.
-  */
- 
-+#include <iterator>
- 
+@@ -9,3 +0,4 @@
  #include "include/utils/SkParse.h"
+ 
++#include <algorithm> // std::lower_bound
  

--- a/recipes/qt/5.x.x/patches/chromium-skia-missing-iterator-include.patch
+++ b/recipes/qt/5.x.x/patches/chromium-skia-missing-iterator-include.patch
@@ -1,0 +1,12 @@
+diff --git a/chromium/third_party/skia/src/utils/SkParseColor.cpp b/chromium/third_party/skia/src/utils/SkParseColor.cpp
+index 7260365b2c6..96f46dd67f9 100644
+--- a/chromium/third_party/skia/src/utils/SkParseColor.cpp
++++ b/chromium/third_party/skia/src/utils/SkParseColor.cpp
+@@ -5,6 +5,7 @@
+  * found in the LICENSE file.
+  */
+ 
++#include <iterator>
+ 
+ #include "include/utils/SkParse.h"
+ 

--- a/recipes/qt/5.x.x/patches/chromium-v8-missing-constexpr.patch
+++ b/recipes/qt/5.x.x/patches/chromium-v8-missing-constexpr.patch
@@ -1,7 +1,27 @@
-diff --git a/chromium/v8/src/compiler/node.h b/chromium/v8/src/compiler/node.h
-index 1936f06457e..83ff9e256ce 100644
---- a/chromium/v8/src/compiler/node.h
-+++ b/chromium/v8/src/compiler/node.h
+From a5cea1bfc38ceafc74f4baddd6ab94ea13757ef8 Mon Sep 17 00:00:00 2001
+From: Lei Zhang <thestig@chromium.org>
+Date: Fri, 21 May 2021 10:55:53 -0700
+Subject: [PATCH] Mark Node::opcode() and Operator::opcode() as constexpr.
+
+Without the explicit constexpr keyword, Clang seems to be able to treat
+these methods as constexpr, whereas MSVC will not.
+
+Bug: v8:11760
+Change-Id: I9f6492f38fb50dcaf7a4f09da0bd79c0da6a50eb
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2912916
+Reviewed-by: Clemens Backes <clemensb@chromium.org>
+Reviewed-by: Maya Lekova <mslekova@chromium.org>
+Commit-Queue: Lei Zhang <thestig@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#74791}
+---
+ src/compiler/node.h     | 2 +-
+ src/compiler/operator.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/compiler/node.h b/src/compiler/node.h
+index 37b45c403f1..57d49fe1ac0 100644
+--- a/src/compiler/node.h
++++ b/src/compiler/node.h
 @@ -50,7 +50,7 @@ class V8_EXPORT_PRIVATE Node final {
  
    const Operator* op() const { return op_; }
@@ -11,10 +31,10 @@ index 1936f06457e..83ff9e256ce 100644
      DCHECK_GE(IrOpcode::kLast, op_->opcode());
      return static_cast<IrOpcode::Value>(op_->opcode());
    }
-diff --git a/chromium/v8/src/compiler/operator.h b/chromium/v8/src/compiler/operator.h
-index 7227c92cd86..94d70588672 100644
---- a/chromium/v8/src/compiler/operator.h
-+++ b/chromium/v8/src/compiler/operator.h
+diff --git a/src/compiler/operator.h b/src/compiler/operator.h
+index 4206e753f1e..f641394eb1f 100644
+--- a/src/compiler/operator.h
++++ b/src/compiler/operator.h
 @@ -69,7 +69,7 @@ class V8_EXPORT_PRIVATE Operator : public NON_EXPORTED_BASE(ZoneObject) {
    // A small integer unique to all instances of a particular kind of operator,
    // useful for quick matching for specific kinds of operators. For fast access

--- a/recipes/qt/5.x.x/patches/chromium-v8-missing-constexpr.patch
+++ b/recipes/qt/5.x.x/patches/chromium-v8-missing-constexpr.patch
@@ -1,0 +1,26 @@
+diff --git a/chromium/v8/src/compiler/node.h b/chromium/v8/src/compiler/node.h
+index 1936f06457e..83ff9e256ce 100644
+--- a/chromium/v8/src/compiler/node.h
++++ b/chromium/v8/src/compiler/node.h
+@@ -50,7 +50,7 @@ class V8_EXPORT_PRIVATE Node final {
+ 
+   const Operator* op() const { return op_; }
+ 
+-  IrOpcode::Value opcode() const {
++  constexpr IrOpcode::Value opcode() const {
+     DCHECK_GE(IrOpcode::kLast, op_->opcode());
+     return static_cast<IrOpcode::Value>(op_->opcode());
+   }
+diff --git a/chromium/v8/src/compiler/operator.h b/chromium/v8/src/compiler/operator.h
+index 7227c92cd86..94d70588672 100644
+--- a/chromium/v8/src/compiler/operator.h
++++ b/chromium/v8/src/compiler/operator.h
+@@ -69,7 +69,7 @@ class V8_EXPORT_PRIVATE Operator : public NON_EXPORTED_BASE(ZoneObject) {
+   // A small integer unique to all instances of a particular kind of operator,
+   // useful for quick matching for specific kinds of operators. For fast access
+   // the opcode is stored directly in the operator object.
+-  Opcode opcode() const { return opcode_; }
++  constexpr Opcode opcode() const { return opcode_; }
+ 
+   // Returns a constant string representing the mnemonic of the operator,
+   // without the static parameters. Useful for debugging.


### PR DESCRIPTION
Specify library name and version:  **qt/5.15.3**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
