### PR TITLE
Qt6 patches cleanup: port pri-helpers-fix patch

### DIFF
--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -66,10 +66,16 @@ patches:
     - base_path: "qtwebengine"
       patch_description: "Workaround for too long .rps file name"
       patch_file: "patches/c72097e.diff"
+    - base_path: "qtbase/cmake"
+      patch_description: "Fix pri helpers, see PR #6668 and QTBUG-95569"
+      patch_file: "patches/qt6.5.0-pri-helpers-fix.diff"
   "6.5.0":
     - base_path: "qtwebengine"
       patch_description: "Workaround for too long .rps file name"
       patch_file: "patches/c72097e.diff"
+    - base_path: "qtbase/cmake"
+      patch_description: "Fix pri helpers, see PR #6668 and QTBUG-95569"
+      patch_file: "patches/qt6.5.0-pri-helpers-fix.diff"
   "6.4.2":
     - base_path: "qtbase/cmake"
       patch_description: "Fix pri helpers"

--- a/recipes/qt/6.x.x/patches/qt6.5.0-pri-helpers-fix.diff
+++ b/recipes/qt/6.x.x/patches/qt6.5.0-pri-helpers-fix.diff
@@ -1,0 +1,15 @@
+--- QtPriHelpers.cmake	2023-05-12 12:40:15.000000000 +0800
++++ QtPriHelpers.cmake	2023-07-06 11:39:58.305927536 +0800
+@@ -33,7 +33,11 @@
+                 if(lib_target_type STREQUAL "INTERFACE_LIBRARY")
+                     get_target_property(iface_libs ${lib_target} INTERFACE_LINK_LIBRARIES)
+                     if(iface_libs)
+-                        list(PREPEND lib_targets ${iface_libs})
++                        foreach (iface_lib ${iface_libs})
++                            if (NOT "${iface_lib}" STREQUAL "${lib_target}")
++                                list(PREPEND lib_targets ${iface_lib})
++                            endif ()
++                        endforeach ()
+                     endif()
+                 else()
+                     list(APPEND lib_libs "$<TARGET_LINKER_FILE:${lib_target}>")


### PR DESCRIPTION
I had to merge master first, so the merge looks huge.
This was to bring in the 6.5.1 version from master.
Is there a better way to do this?