### PR TITLE
Update conanfile.py

### DIFF
--- a/recipes/libpcap/all/conanfile.py
+++ b/recipes/libpcap/all/conanfile.py
@@ -98,6 +98,7 @@ class LibPcapConan(ConanFile):
                 # to inject this compilation flag themselves
                 tc.variables["USE_STATIC_RT"] = False
             tc.cache_variables["DISABLE_DPDK"] = True
+            tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_OpenSSL"] = True
 
             if Version(self.version) >= "1.10.5":
                 self.output.warning("PCAP on Windows is currently built with package capture capabilities - only support is for reading/writing capture files")


### PR DESCRIPTION
libpcap: disable openssl

it's not in the dependency of the recipe, so we risk linking to system openssl


### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
