### PR TITLE
wxwidgets: fix libdir on windows ARM

### DIFF
--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -409,7 +409,7 @@ class wxWidgetsConan(ConanFile):
                                "gcc": "gcc",
                                "clang": "clang"}.get(str(self.settings.compiler))
 
-            arch_suffix = "_x64" if self.settings.arch == "x86_64" else ""
+            arch_suffix = "_x64" if self.settings.arch in ["x86_64", "armv8"] else ""
             lib_suffix = "_dll" if self.options.shared else "_lib"
             basedir = f"{compiler_prefix}{arch_suffix}{lib_suffix}"
             libdir = os.path.join("lib", basedir)


### PR DESCRIPTION
https://github.com/wxWidgets/wxWidgets/blob/8d8967a29ac76b78a02b79eab7494545f09fff06/build/cmake/init.cmake#L176-L177


### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
